### PR TITLE
Implement origin validation for WebSocket connections

### DIFF
--- a/server/main/main.go
+++ b/server/main/main.go
@@ -94,6 +94,13 @@ func getClientIP(r *http.Request) string {
 }
 
 func wsEndpoint(w http.ResponseWriter, r *http.Request) {
+       origin := r.Header.Get("Origin")
+       // Allow only requests from "https://blubber.run.place"
+       if origin != "https://blubber.run.place" {
+       		http.Error(w, "Forbidden", http.StatusForbidden)
+         	return
+       }
+
 	var userData network.UserData
 
 	userData.ClientIP = getClientIP(r)


### PR DESCRIPTION
func wsEndpoint(w http.ResponseWriter, r *http.Request) {
  origin := r.Header.Get("Origin")
  if origin != "https://blubber.run.place" {
    http.Error(w, "Forbidden", http.StatusForbidden)
    return
  }
  // ... rest of wsEndpoint
}